### PR TITLE
Av/delete_videos_upon_tutorial_delete

### DIFF
--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -18,6 +18,12 @@ class Admin::TutorialsController < Admin::BaseController
     redirect_to edit_admin_tutorial_path(tutorial)
   end
 
+  def destroy
+    Tutorial.destroy(params[:id])
+
+    redirect_to admin_dashboard_path
+  end
+
   private
   def tutorial_params
     params.require(:tutorial).permit(:tag_list)

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,5 +1,5 @@
 class Tutorial < ApplicationRecord
-  has_many :videos, ->  { order(position: :ASC) }
+  has_many :videos, ->  { order(position: :ASC) }, dependent: :destroy
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
 end

--- a/app/views/admin/dashboard/show.html.erb
+++ b/app/views/admin/dashboard/show.html.erb
@@ -11,13 +11,11 @@
     <th>Actions</th>
   </tr>
   <% @facade.tutorials.each do |tutorial| %>
-    <tr class="admin-tutorial-card">
+    <tr class="admin-tutorial-card" id = "tutorial-<%= tutorial.id %>" >
       <td><%= link_to tutorial.title, tutorial_path(tutorial) %></td>
       <td>
         <%= link_to "Edit", edit_admin_tutorial_path(tutorial) %> |
-        <%= link_to 'Destroy', tutorial_path(tutorial),
-                               method: :delete,
-                               data: { confirm: 'Are you sure?' } %>
+        <%= link_to 'Destroy', "/admin/tutorials/#{tutorial.id}", method: :delete, data: { confirm: 'Are you sure?' } %>
       </td>
     </tr>
   <% end %>

--- a/app/views/admin/dashboard/show.html.erb
+++ b/app/views/admin/dashboard/show.html.erb
@@ -15,7 +15,7 @@
       <td><%= link_to tutorial.title, tutorial_path(tutorial) %></td>
       <td>
         <%= link_to "Edit", edit_admin_tutorial_path(tutorial) %> |
-        <%= link_to 'Destroy', "/admin/tutorials/#{tutorial.id}", method: :delete, data: { confirm: 'Are you sure?' } %>
+        <%= button_to 'Destroy', "/admin/tutorials/#{tutorial.id}", method: :delete, data: { confirm: 'Are you sure?' } %>
       </td>
     </tr>
   <% end %>

--- a/app/views/admin/dashboard/show.html.erb
+++ b/app/views/admin/dashboard/show.html.erb
@@ -14,8 +14,8 @@
     <tr class="admin-tutorial-card" id = "tutorial-<%= tutorial.id %>" >
       <td><%= link_to tutorial.title, tutorial_path(tutorial) %></td>
       <td>
-        <%= link_to "Edit", edit_admin_tutorial_path(tutorial) %> |
-        <%= button_to 'Destroy', "/admin/tutorials/#{tutorial.id}", method: :delete, data: { confirm: 'Are you sure?' } %>
+        <%= link_to "Edit", edit_admin_tutorial_path(tutorial) %> 
+        <%= button_to 'Destroy', "/admin/tutorials/#{tutorial.id}", method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-primary mb1 bg-teal"%>
       </td>
     </tr>
   <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,7 @@
+User.destroy_all
+Tutorial.destroy_all
+Video.destroy_all
+
 prework_tutorial_data = {
   "title"=>"Back End Engineering - Prework",
   "description"=>"Videos for prework.",

--- a/spec/features/admin/tutorials/destroy_spec.rb
+++ b/spec/features/admin/tutorials/destroy_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe "As an admin user" do
+  describe "when I visit my admin dashboard" do
+    describe "I click on the delete button next to a tutorial" do
+      scenario  "the tutorial is deleted along with its videos" do
+        admin = create(:user, role: :admin)
+        tutorial_1 = create(:tutorial)
+        tutorial_2 = create(:tutorial)
+        tutorial_3 = create(:tutorial)
+
+        video_1 = create(:video, tutorial: tutorial_1)
+        video_2 = create(:video, tutorial: tutorial_2)
+        video_3 = create(:video, tutorial: tutorial_3)
+
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+        visit '/admin/dashboard'
+
+        expect(page).to have_css(".admin-tutorial-card", count: 3)
+
+        within("#tutorial-#{tutorial_1.id}") do
+          expect {
+            click_link 'Destroy'
+          }.to change { Tutorial.count }.by(-1)
+            .and change { Video.count }.by(-1)
+        end
+
+        expect(current_path).to eq('/admin/dashboard')
+
+        expect(page).to have_css(".admin-tutorial-card", count: 2)
+        expect(page).to_not have_css("#tutorial-#{tutorial_1.id}")
+        expect(Video.find_by(id: video_1.id)).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/features/admin/tutorials/destroy_spec.rb
+++ b/spec/features/admin/tutorials/destroy_spec.rb
@@ -21,7 +21,7 @@ describe "As an admin user" do
 
         within("#tutorial-#{tutorial_1.id}") do
           expect {
-            click_link 'Destroy'
+            click_button 'Destroy'
           }.to change { Tutorial.count }.by(-1)
             .and change { Video.count }.by(-1)
         end


### PR DESCRIPTION
**Functionality:**
- The purpose of this branch was to destroy videos belonging to a tutorial that gets deleted. 
- The original code did not have a functioning `destroy` link, which is accessible from the `admin/dashboard` page. When this link was clicked, it took you to the show page.
- To make this tutorial destroy action work:
    - `link_to` was replaced with `button_to` as `link_to` was causing a `GET` request to be sent to `admin/tutorials/id` instead of a `delete` request, despite the `method: :delete` being included in the link. 
        - A line has been added to our legacy issues card to check on this, as multiple online sources point to a `jquery` issues.
- A `destroy` action was added to admin tutorials controller
- Tutorial model was updated with a dependent destroy for videos.

**Testing:**
- The new test is nested under `spec/features/admin/tutorials/destroy_spec.rb`, as there was no test for tutorial destroy in the legacy code base. 
- Rspec running at 65.23% coverage. 

**Related Issues:**
- #5 