### PR TITLE
Rubocop updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,8 +18,5 @@ Style/FrozenStringLiteralComment:
 Style/Documentation:
   Enabled: false
 
-Metrics/LineLength:
-  Max: 120
-
 Metrics/ClassLength:
   Max: 1500

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,6 @@ Style/Documentation:
 
 Metrics/ClassLength:
   Max: 1500
+
+Layout/LineLength:
+  Max: 120

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'yt', '~> 0.29.1'
 
 group :development, :test do
   gem 'awesome_print'
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'capybara'
   gem 'database_cleaner'
   gem 'foundation-rails'
@@ -46,4 +46,4 @@ group :development do
   gem 'web-console', '>= 3.3.0'
 end
 
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -2,50 +2,48 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.4.1'
-gem 'rails', '~> 5.2.0'
-gem 'pg', '>= 0.18', '< 2.0'
-gem 'puma', '~> 3.11'
-gem 'sass-rails', '~> 5.0'
-# gem 'uglifier', '>= 1.3.0'
-gem 'coffee-rails', '~> 4.2'
-gem 'jbuilder', '~> 2.5'
-gem 'bootsnap', '>= 1.1.0', require: false
+gem 'active_model_serializers'
+gem 'acts-as-taggable-on', '~> 6.0'
 gem 'bcrypt', '~> 3.1.7'
-gem 'webpacker', '~> 3.5'
-gem 'yt', '~> 0.29.1'
-gem 'google-api-client'
-gem 'faraday'
-gem 'jquery'
-gem 'figaro'
+gem 'bootsnap', '>= 1.1.0', require: false
+gem 'coffee-rails', '~> 4.2'
 gem 'factory_bot_rails'
 gem 'faker'
-gem 'active_model_serializers'
-gem 'omniauth-google-oauth2'
-gem 'will_paginate'
-gem 'acts-as-taggable-on', '~> 6.0'
-gem 'omniauth-census', git: "https://github.com/turingschool-projects/omniauth-census"
+gem 'faraday'
+gem 'figaro'
+gem 'google-api-client'
+gem 'jbuilder', '~> 2.5'
+gem 'jquery'
 gem 'omniauth-github'
+gem 'omniauth-google-oauth2'
+gem 'pg', '>= 0.18', '< 2.0'
+gem 'puma', '~> 3.11'
+gem 'rails', '~> 5.2.0'
+gem 'sass-rails', '~> 5.0'
+gem 'webpacker', '~> 3.5'
+gem 'will_paginate'
+gem 'yt', '~> 0.29.1'
 
 group :development, :test do
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'rspec-rails'
-  gem 'foundation-rails'
-  gem 'database_cleaner'
-  gem 'pry'
-  gem 'capybara'
-  gem 'launchy'
-  gem 'shoulda-matchers'
   gem 'awesome_print'
-  gem 'webmock'
+  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'capybara'
+  gem 'database_cleaner'
+  gem 'foundation-rails'
+  gem 'launchy'
+  gem 'pry'
+  gem 'rspec-rails'
+  gem 'selenium-webdriver'
+  gem 'shoulda-matchers'
   gem 'simplecov'
   gem 'vcr'
-  gem 'selenium-webdriver'
   gem 'webdrivers'
+  gem 'webmock'
 end
 
 group :development do
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'web-console', '>= 3.3.0'
 end
 
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/turingschool-projects/omniauth-census
-  revision: b0a60a01f6aadefdc01ad0ec70d070769aa4f321
-  specs:
-    omniauth-census (0.1.12)
-      omniauth-oauth2 (~> 1.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -346,7 +339,6 @@ DEPENDENCIES
   jquery
   launchy
   listen (>= 3.0.5, < 3.2)
-  omniauth-census!
   omniauth-github
   omniauth-google-oauth2
   pg (>= 0.18, < 2.0)
@@ -371,4 +363,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/app/controllers/about_controller.rb
+++ b/app/controllers/about_controller.rb
@@ -1,4 +1,3 @@
 class AboutController < ApplicationController
-  def show
-  end
+  def show; end
 end


### PR DESCRIPTION
**Functionality:**
 - Update rubocop yml file to use updated syntax for line length
- Alphabetize gemfile and removed omniauth-census (https://github.com/turingschool-projects/omniauth-census) from the gemfile. Based on its documentation, I don't see where it's being used and everything still passes with it removed. 

**Testing:**
Just edits in yml and syntax - so no tests were added. 

**Related Issues:**
