### PR TITLE
Refactor invite emails

### DIFF
--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -4,25 +4,38 @@ class InviteController < ApplicationController
   def create
     service = GithubService.new(current_user.github_token)
 
-    handle = params[:github_handle]
-
-    if service.user_exists?(handle)
-      invitee = service.get_user(handle)
-      invitee_email = invitee[:email]
-      invitee_name = invitee[:name]
-      if invitee_email.nil?
-        flash[:error] = "The Github user you selected doesn't have an email address associated with their account."
-        render :new
-      else
-
-        InviteMailer.invite_user(invitee_email, invitee_name, current_user.first_name).deliver_now
-        flash[:success] = 'Successfully sent invite!'
-
-        redirect_to dashboard_path
-      end
-    else
+    if !service.user_exists?(params[:github_handle])
       flash[:error] = 'There is no Github user with that handle.'
       render :new
+    else
+      invitee = service.get_user(params[:github_handle])
+      attempt_to_send_email(invitee)
+    end
+  end
+
+  private
+
+  def send_invite_email(invitee_email, invitee_name, sender_name)
+    InviteMailer.invite_user(invitee_email, invitee_name, sender_name).deliver_now
+    flash[:success] = 'Successfully sent invite!'
+    redirect_to dashboard_path
+  end
+
+  def send_email_if_new_user(invitee)
+    if User.exists?(uid: invitee[:id])
+      flash[:error] = 'The Github user already has an account with Brownfield of Dreams.'
+      render :new
+    else
+      send_invite_email(invitee[:email], invitee[:name], current_user.full_name)
+    end
+  end
+
+  def attempt_to_send_email(invitee)
+    if invitee[:email].nil?
+      flash[:error] = "The Github user you selected doesn't have an email address associated with their account."
+      render :new
+    else
+      send_email_if_new_user(invitee)
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,10 +18,11 @@ class User < ApplicationRecord
   enum role: %i[default admin]
 
   def status
-    if active?
-      'Active'
-    else
-      'Inactive'
-    end
+    return 'Active' if active?
+    return 'Inactive' if !active?
+  end
+
+  def full_name
+    "#{first_name} #{last_name}"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
 
   def status
     return 'Active' if active?
-    return 'Inactive' if !active?
+    return 'Inactive' unless active?
   end
 
   def full_name

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -32,9 +32,10 @@ class GithubService
   private
 
   def conn
-    connection = Faraday.new(url: 'https://api.github.com/')
-    connection.basic_auth(nil, @github_token)
-    connection
+    connection = Faraday.new(url: 'https://api.github.com/') do |faraday|
+      faraday.headers['Authorization'] = "token #{@github_token}"
+      faraday.adapter Faraday.default_adapter
+    end
   end
 
   def response(url)

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -32,7 +32,7 @@ class GithubService
   private
 
   def conn
-    connection = Faraday.new(url: 'https://api.github.com/') do |faraday|
+    Faraday.new(url: 'https://api.github.com/') do |faraday|
       faraday.headers['Authorization'] = "token #{@github_token}"
       faraday.adapter Faraday.default_adapter
     end

--- a/app/views/invite/new.html.erb
+++ b/app/views/invite/new.html.erb
@@ -4,8 +4,6 @@
       <%= label_tag :github_handle %>
       <%= text_field_tag :github_handle %>
 
-      <%= submit_tag 'Send Invite' %>
+      <%= submit_tag 'Send Invite', class: "btn btn-primary mb1 bg-teal" %>
     <% end %>
-
-
 </section>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -135,5 +135,5 @@ m3_tutorial.videos.create!({
 
 User.create!(email: 'admin@example.com', first_name: 'Bossy', last_name: 'McBosserton', password:  "password", role: :admin)
 
-User.create!(email: 'ali@gmail.com', first_name: 'Ali', last_name: 'Smith', password:  "password", github_token: ENV["GITHUB_TOKEN_ALI"], uid: 51250305)
-User.create!(email: 'linda@gmail.com', first_name: 'Linda', last_name: 'Johnson', password:  "password", github_token: ENV["GITHUB_TOKEN_LINDA"], uid: 54052410)
+# User.create!(email: 'ali@gmail.com', first_name: 'Ali', last_name: 'Smith', password:  "password", github_token: ENV["GITHUB_TOKEN_ALI"], uid: 51250305)
+# User.create!(email: 'linda@gmail.com', first_name: 'Linda', last_name: 'Johnson', password:  "password", github_token: ENV["GITHUB_TOKEN_LINDA"], uid: 54052410)

--- a/spec/cassettes/An_Admin_can_edit_a_tutorial/by_adding_a_video.yml
+++ b/spec/cassettes/An_Admin_can_edit_a_tutorial/by_adding_a_video.yml
@@ -1,0 +1,123 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.googleapis.com/youtube/v3/videos?id=J7ikFUlkP_k&key=<YOUTUBE_API_KEY>&part=snippet,contentDetails,statistics
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.12.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - Thu, 13 Feb 2020 18:04:08 GMT
+      Date:
+      - Thu, 13 Feb 2020 18:04:08 GMT
+      Cache-Control:
+      - private, max-age=0, must-revalidate, no-transform
+      Etag:
+      - '"Fznwjl6JEQdo1MGvHOGaz_YanRU/h6pzuVMu8FMPoHF01_vUx7pJZTY"'
+      Vary:
+      - Origin
+      - X-Origin
+      Content-Type:
+      - application/json; charset=UTF-8
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43",h3-Q050=":443"; ma=2592000,h3-Q049=":443";
+        ma=2592000,h3-Q048=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443";
+        ma=2592000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+         "kind": "youtube#videoListResponse",
+         "etag": "\"Fznwjl6JEQdo1MGvHOGaz_YanRU/h6pzuVMu8FMPoHF01_vUx7pJZTY\"",
+         "pageInfo": {
+          "totalResults": 1,
+          "resultsPerPage": 1
+         },
+         "items": [
+          {
+           "kind": "youtube#video",
+           "etag": "\"Fznwjl6JEQdo1MGvHOGaz_YanRU/4-6UFAILfbqODE8m7ZRljTRM7oQ\"",
+           "id": "J7ikFUlkP_k",
+           "snippet": {
+            "publishedAt": "2018-07-23T20:59:59.000Z",
+            "channelId": "UC2zYYOtckevoWTGDu5SdCkg",
+            "title": "Rails Integration Tests for Pages with JavaScript",
+            "description": "This video shows how to write feature/integration tests within RSpec configured to run expectations for pages that run JavaScript.",
+            "thumbnails": {
+             "default": {
+              "url": "https://i.ytimg.com/vi/J7ikFUlkP_k/default.jpg",
+              "width": 120,
+              "height": 90
+             },
+             "medium": {
+              "url": "https://i.ytimg.com/vi/J7ikFUlkP_k/mqdefault.jpg",
+              "width": 320,
+              "height": 180
+             },
+             "high": {
+              "url": "https://i.ytimg.com/vi/J7ikFUlkP_k/hqdefault.jpg",
+              "width": 480,
+              "height": 360
+             },
+             "standard": {
+              "url": "https://i.ytimg.com/vi/J7ikFUlkP_k/sddefault.jpg",
+              "width": 640,
+              "height": 480
+             },
+             "maxres": {
+              "url": "https://i.ytimg.com/vi/J7ikFUlkP_k/maxresdefault.jpg",
+              "width": 1280,
+              "height": 720
+             }
+            },
+            "channelTitle": "Turing School of Software and Design",
+            "categoryId": "28",
+            "liveBroadcastContent": "none",
+            "localized": {
+             "title": "Rails Integration Tests for Pages with JavaScript",
+             "description": "This video shows how to write feature/integration tests within RSpec configured to run expectations for pages that run JavaScript."
+            }
+           },
+           "contentDetails": {
+            "duration": "PT16M16S",
+            "dimension": "2d",
+            "definition": "hd",
+            "caption": "false",
+            "licensedContent": false,
+            "projection": "rectangular"
+           },
+           "statistics": {
+            "viewCount": "255",
+            "likeCount": "2",
+            "dislikeCount": "0",
+            "favoriteCount": "0",
+            "commentCount": "0"
+           }
+          }
+         ]
+        }
+    http_version: 
+  recorded_at: Thu, 13 Feb 2020 18:04:05 GMT
+recorded_with: VCR 4.0.0

--- a/spec/features/admin/tutorials/admin_can_edit_tutorials_spec.rb
+++ b/spec/features/admin/tutorials/admin_can_edit_tutorials_spec.rb
@@ -4,7 +4,7 @@ describe "An Admin can edit a tutorial" do
   let(:tutorial) { create(:tutorial) }
   let(:admin)    { create(:admin) }
 
-  xscenario "by adding a video", :js, :vcr do
+  scenario "by adding a video", :js, :vcr do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
     visit edit_admin_tutorial_path(tutorial)

--- a/spec/features/user/github/user_can_invite_a_person_spec.rb
+++ b/spec/features/user/github/user_can_invite_a_person_spec.rb
@@ -64,6 +64,26 @@ RSpec.describe "As a logged in user" do
         expect(page).to have_button 'Send Invite'
       end
     end
+
+    scenario "I am alerted if the invitee is already an app user" do
+      user = create(:user, github_token: ENV["GITHUB_TOKEN_LINDA"])
+      user_2 = create(:user, github_token: ENV["GITHUB_TOKEN_ALI"], uid: 51250305)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+      visit dashboard_path
+
+      click_button 'Send an Invite'
+
+      expect(current_path).to eq('/invite')
+
+      fill_in :github_handle, with: 'mintona'
+
+      click_button 'Send Invite'
+
+      expect(page).to have_content("The Github user already has an account with Brownfield of Dreams.")
+      expect(page).to have_button 'Send Invite'
+    end
   end
 
   describe "As the invitee" do

--- a/spec/mailers/invite_mailer_spec.rb
+++ b/spec/mailers/invite_mailer_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 describe InviteMailer, type: :mailer do
     describe "When a user sends an invite to a non registered user to join the app" do
         before :each do
-            # @user = create(:user, email: "example@gmail.com")
             @email_address = 'ali@gmail.com'
             @name = 'Alison Vermeil'
             @sender_name = 'Linda'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -53,6 +53,13 @@ RSpec.describe User, type: :model do
         expect(user_2.status).to eq("Active")
       end
     end
+
+    describe '#full_name' do
+      it 'displays the first and last name of the user' do
+        user = create(:user, first_name: "Ali", last_name: "Smith")
+
+        expect(user.name).to eq("Ali Smith")
+      end
+    end
   end
 end
-

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe User, type: :model do
       it 'displays the first and last name of the user' do
         user = create(:user, first_name: "Ali", last_name: "Smith")
 
-        expect(user.name).to eq("Ali Smith")
+        expect(user.full_name).to eq("Ali Smith")
       end
     end
   end


### PR DESCRIPTION
**Functionality:**
- Added another sad path so an invitee who is already authenticated by github and a user of our app will not get the invite email 
- Refactored the invite controller create action into helper methods

**Testing:**
- Fixed youtube API key and were able to run the skipped legacy test
- New code fully tested
- Full suite up to 87.82%

**Related Issues:**
- #6 